### PR TITLE
既存の処理が実行中の場合、処理を待つ

### DIFF
--- a/.github/workflows/frontend-ecs-build-and-deploy.yml
+++ b/.github/workflows/frontend-ecs-build-and-deploy.yml
@@ -111,6 +111,28 @@ jobs:
 
           # APPSPEC_CONTENTを出力
           echo "$APPSPEC_CONTENT"
+
+          # 現在のデプロイメントを取得
+          CURRENT_DEPLOYMENT=$(aws deploy list-deployments \
+            --application-name ${{ secrets.PROJECT }}-frontend-app-${{ inputs.env_var }} \
+            --deployment-group-name ${{ secrets.PROJECT }}-frontend-dg-${{ inputs.env_var }} \
+            --include-only-statuses InProgress \
+            --query 'deployments[0]' \
+            --output text \
+            --region ${{ env.AWS_REGION }})
+
+          # 進行中のデプロイメントがある場合、停止する
+          if [ ! -z "$CURRENT_DEPLOYMENT" ]; then
+            echo "Stopping current deployment: $CURRENT_DEPLOYMENT"
+            aws deploy stop-deployment \
+              --deployment-id $CURRENT_DEPLOYMENT \
+              --region ${{ env.AWS_REGION }}
+            
+            # デプロイメントが完全に停止するまで待機
+            aws deploy wait deployment-stopped \
+              --deployment-id $CURRENT_DEPLOYMENT \
+              --region ${{ env.AWS_REGION }}
+          fi
           
           # CodeDeployを使用してデプロイを開始
           aws deploy create-deployment \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- GitHub Actionsのワークフローに、進行中のデプロイメントを管理する新しいロジックを追加しました。これにより、新しいデプロイメントの前に進行中のものを停止することができます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->